### PR TITLE
Allow external IP addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ services:
 | `PROXY_PASSWORD` | | Credentials for accessing the proxies. If `PROXY_PASSWORD` is specified, you must also specify `PROXY_USERNAME`. |
 | `PROXY_USERNAME_SECRET` | | Docker secrets that contain the credentials for accessing the proxies. If `PROXY_USERNAME_SECRET` is specified, you must also specify `PROXY_PASSWORD_SECRET`. |
 | `PROXY_PASSWORD_SECRET` | | Docker secrets that contain the credentials for accessing the proxies. If `PROXY_PASSWORD_SECRET` is specified, you must also specify `PROXY_USERNAME_SECRET`. |
+| `LISTEN_ON` | | Address the proxies will be listening on. Set to `0.0.0.0` to allow all IP addresses. |
 
 ##### Environment variable considerations
 ###### `SUBNETS`

--- a/data/scripts/entry.sh
+++ b/data/scripts/entry.sh
@@ -39,7 +39,8 @@ SOCKS proxy: ${SOCKS_PROXY:-off}
 Proxy username secret: ${PROXY_PASSWORD_SECRET:-none}
 Proxy password secret: ${PROXY_USERNAME_SECRET:-none}
 Allowing subnets: ${SUBNETS:-none}
-Using OpenVPN log level: $vpn_log_level"
+Using OpenVPN log level: $vpn_log_level
+Listening on: ${LISTEN_ON:-none}"
 
 if [ -n "$VPN_CONFIG_FILE" ]; then
     config_file_original="/data/vpn/$VPN_CONFIG_FILE"
@@ -165,6 +166,9 @@ if [ "$HTTP_PROXY" = "on" ]; then
 fi
 
 if [ "$SOCKS_PROXY" = "on" ]; then
+    if [ "$LISTEN_ON" ]; then
+            sed -i "s/internal: eth0/internal: $LISTEN_ON/" /data/sockd.conf    
+    fi
     if [ "$PROXY_USERNAME" ]; then
         if [ "$PROXY_PASSWORD" ]; then
             echo "Configuring SOCKS proxy authentication."

--- a/data/scripts/tinyproxy_wrapper.sh
+++ b/data/scripts/tinyproxy_wrapper.sh
@@ -8,8 +8,12 @@ until ip link show tun0 2>&1 | grep -qv "does not exist"; do
     sleep 1
 done
 
-addr_eth=$(ip a show dev eth0 | grep inet | cut -d " " -f 6 | cut -d "/" -f 1)
-addr_tun=$(ip a show dev tun0 | grep inet | cut -d " " -f 6 | cut -d "/" -f 1)
+function get_addr {
+   echo $(ip a show dev $1 | grep inet | cut -d " " -f 6 | cut -d "/" -f 1)
+} 
+
+addr_eth=${LISTEN_ON:-$(get_addr eth0)}
+addr_tun=$(get_addr tun0)
 sed -i \
     -e "/Listen/c Listen $addr_eth" \
     -e "/Bind/c Bind $addr_tun" \


### PR DESCRIPTION
When using the image in a Kubernetes pod, the proxies must accept incoming traffic from other pods. This PR adds the option to specify an address for incoming traffic other than the one of `eth0`